### PR TITLE
Trigger admin notification mail upon payment

### DIFF
--- a/classes/MolliePayment.php
+++ b/classes/MolliePayment.php
@@ -8,6 +8,7 @@ use OFFLINE\Mall\Models\Order;
 use Throwable;
 use Session;
 use Log;
+use Event;
 
 class MolliePayment extends PaymentProvider
 {
@@ -162,6 +163,10 @@ class MolliePayment extends PaymentProvider
 
             // Update the order based on the payment status that Mollie has provided
             if ($payment->isPaid()) {
+                
+                // Send a notification to the admin, confirming that the checkout has succeeded
+                Event::fire('mall.checkout.succeeded', [$result]);
+                
                 return $result->success((array) $payment, trans("offline.mall::lang.payment_status.paid"));
             } elseif ($payment->isFailed()) {
                 return $result->fail((array) $payment, trans("offline.mall::lang.payment_status.failed"));


### PR DESCRIPTION
This edit triggers the mall.checkout.succeeded mail. The only issue is that the succesful payment isn't logged in the mail yet. This is because we trigger the admin mail before we set the payment status to paid. 
Could we change the code in such a way that the admin mail is sent after setting the payment state to paid?

![image](https://user-images.githubusercontent.com/3584586/141160121-88f203b1-ca47-45fc-b04f-61e704aa69c0.png)
